### PR TITLE
Fix: nonexistent video 'file_name'

### DIFF
--- a/protect_content/cloneplan/cloneplan.py
+++ b/protect_content/cloneplan/cloneplan.py
@@ -44,7 +44,8 @@ def enrich_fields(cloneplan_dict, msg, key):
     if key == "video":
         cloneplan_dict["duration"] = msg["video"]["duration"]
         cloneplan_dict["file_size"] = msg["video"]["file_size"]
-        cloneplan_dict["file_name"] = msg["video"]["file_name"]
+        cloneplan_dict["file_name"] = msg["video"].get("file_name", (str(msg["id"]) + '-' + msg["video"]["file_unique_id"] + '.' + (
+            ".mp4" if msg["video"]["mime_type"] == 'video/mp4' else '.mov' if msg["video"]["mime_type"] == 'video/quicktime' else '.mkv')))
         return cloneplan_dict
     if key == "document":
         cloneplan_dict["file_size"] = msg["document"]["file_size"]


### PR DESCRIPTION
Videos may not have the 'file_name' key, causing an error when trying to set the variable.

Fix bug using as value file_unique_id + most likely file extension based on mime_type